### PR TITLE
Addition of LaBanquePostale and Impots.gouv.fr logout URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,6 +244,7 @@
         ["Hulu", get("https://secure.hulu.com/logout")],
         ["Instapaper", get("http://www.instapaper.com/user/logout")],
         ["KanbanFlow", get("https://kanbanflow.com/logout")],
+        ["LaBanquePostale", get("https://voscomptesenligne.labanquepostale.fr/voscomptes/canalXHTML/securite/deconnexion/init-deconnexion.ea")],
         ["Linode", get("https://manager.linode.com/session/logout")],
         ["LiveJournal", post("http://www.livejournal.com/logout.bml", {"action:killall": "1"})],
         ["MySpace", get("http://www.myspace.com/index.cfm?fuseaction=signout")],

--- a/index.html
+++ b/index.html
@@ -271,6 +271,7 @@
         ["DueDil", get("http://www.duedil.com/logout")],
         ["Podio", get("https://podio.com/logout")],
         ["Codeanywhere", get("https://codeanywhere.com/logout")],
+        ["NESCAFE Dolce Gusto", get("https://www.dolce-gusto.fr/customer/account/logout")],
       ])
     };
 

--- a/index.html
+++ b/index.html
@@ -242,6 +242,7 @@
         ["GMail", get("http://mail.google.com/mail/?logout")],
         ["Google", get("https://www.google.com/accounts/Logout")],
         ["Hulu", get("https://secure.hulu.com/logout")],
+        ["Impots.gouv.fr", get("https://cfspart.impots.gouv.fr/deconnexion")],
         ["Instapaper", get("http://www.instapaper.com/user/logout")],
         ["KanbanFlow", get("https://kanbanflow.com/logout")],
         ["LaBanquePostale", get("https://voscomptesenligne.labanquepostale.fr/voscomptes/canalXHTML/securite/deconnexion/init-deconnexion.ea")],

--- a/index.html
+++ b/index.html
@@ -255,6 +255,7 @@
         ["Skype", get("https://secure.skype.com/account/logout")],
         ["Slashdot", get("http://slashdot.org/my/logout")],
         ["SoundCloud", get("http://soundcloud.com/logout")],
+        ["Spotify", get("https://www.spotify.com/logout/")],
         ["Steam Community", get("http://steamcommunity.com/?action=doLogout")],
         ["Steam Store", get("http://store.steampowered.com/logout/")],
         ["ThinkGeek", get("https://www.thinkgeek.com/brain/account/login.cgi?a=lo")],


### PR DESCRIPTION
Addition of LaBanquePostale (French bank account) and Impots.gouv.fr (French tax department) logout URL
